### PR TITLE
Add cuTENSOR 1.3.1.3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,13 +5,9 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cuda_compiler_version10.1:
-        CONFIG: linux_64_cuda_compiler_version10.1
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.1
       linux_64_cuda_compiler_version10.2:
         CONFIG: linux_64_cuda_compiler_version10.2
         UPLOAD_PACKAGES: 'True'
@@ -20,6 +16,10 @@ jobs:
         CONFIG: linux_64_cuda_compiler_version11.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.0
+      linux_64_cuda_compiler_version11.1:
+        CONFIG: linux_64_cuda_compiler_version11.1
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.1
       linux_ppc64le_cuda_compiler_version10.2:
         CONFIG: linux_ppc64le_cuda_compiler_version10.2
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_64_cuda_compiler_version10.1:
-        CONFIG: win_64_cuda_compiler_version10.1
-        UPLOAD_PACKAGES: 'True'
       win_64_cuda_compiler_version10.2:
         CONFIG: win_64_cuda_compiler_version10.2
         UPLOAD_PACKAGES: 'True'
       win_64_cuda_compiler_version11.0:
         CONFIG: win_64_cuda_compiler_version11.0
+        UPLOAD_PACKAGES: 'True'
+      win_64_cuda_compiler_version11.1:
+        CONFIG: win_64_cuda_compiler_version11.1
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_cuda_compiler_version11.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.1.yaml
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-cuda:10.1
+- quay.io/condaforge/linux-anvil-cuda:11.1
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/win_64_cuda_compiler_version11.1.yaml
+++ b/.ci_support/win_64_cuda_compiler_version11.1.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- '11.1'
 cxx_compiler:
 - vs2017
 target_platform:

--- a/README.md
+++ b/README.md
@@ -43,13 +43,6 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cuda_compiler_version10.1</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cutensor-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version10.1" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_cuda_compiler_version10.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
@@ -64,17 +57,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compiler_version11.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cutensor-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.1" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_ppc64le_cuda_compiler_version10.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cutensor-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cuda_compiler_version10.2" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_64_cuda_compiler_version10.1</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cutensor-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version10.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -89,6 +82,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cutensor-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_cuda_compiler_version11.1</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11699&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cutensor-feedstock?branchName=master&jobName=win&configuration=win_64_cuda_compiler_version11.1" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -22,6 +22,8 @@ docker_image:                                    # [os.environ.get("BUILD_PLATFO
    - quay.io/condaforge/linux-anvil-cos7-cuda:10.1    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
    - quay.io/condaforge/linux-anvil-cos7-cuda:10.2    # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
    - quay.io/condaforge/linux-anvil-cuda:11.0         # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+   - quay.io/condaforge/linux-anvil-cuda:11.1         # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
+   - quay.io/condaforge/linux-anvil-cuda:11.2         # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
 
    - quay.io/condaforge/linux-anvil-ppc64le-cuda:10.2   # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
 
@@ -42,6 +44,8 @@ cuda_compiler_version:
   - 10.1                       # [linux64 or win]
   - 10.2                       # [linux64 or win or ppc64le]
   - 11.0                       # [linux64 or win]
+  - 11.1                       # [linux64 or win]
+  - 11.2                       # [linux64 or win]
 
 cudnn:
   - undefined
@@ -50,15 +54,18 @@ cudnn:
   - 7                          # [linux64 or win]
   - 7                          # [linux64 or win]
   - 8                          # [linux64 or win]
+  - 8                          # [linux64 or win]
+  - 8                          # [linux64 or win]
 
-  # TODO: fix this once https://github.com/conda-forge/cudnn-feedstock/issues/18 is fixed
-  - undefined                  # [ppc64le]
+  - 8                          # [ppc64le]
 
 cdt_name:  # [linux]
   - cos6   # [linux64]
   - cos7   # [ppc64le]
 
   - cos6   # [linux64]
+  - cos7   # [linux64]
+  - cos7   # [linux64]
   - cos7   # [linux64]
   - cos7   # [linux64]
   - cos7   # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.2.2" %}
-{% set patch_version = "5" %}
+{% set version = "1.3.1" %}
+{% set patch_version = "3" %}
 
 package:
   name: cutensor
@@ -8,17 +8,18 @@ package:
 source:
   url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-x86_64-{{ version }}.{{ patch_version }}.tar.gz   # [linux64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
   url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-ppc64le-{{ version }}.{{ patch_version }}.tar.gz  # [ppc64le and cuda_compiler_version in ("10.1", "10.2", "11.0")]
-  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-sbsa-{{ version }}.{{ patch_version }}.tar.gz  # [aarch64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
+  # url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-sbsa-{{ version }}.{{ patch_version }}.tar.gz  # [aarch64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
   url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-windows-x86_64-{{ version }}.{{ patch_version }}.zip  # [win64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
 
-  sha256: 954ee22b80d6b82fd4decd42b7faead86af7c3817653b458620a66174e5b89b6  # [linux64]
-  sha256: d914a721b8a6bbfbf4f2bdea3bb51775e5df39abc383d415b3b06bbde2a47e6e  # [ppc64le]
-  sha256: 031b75946d2ce22f8c2736f7b4216b9377406afcb35012093a66e2801bfe2990  # [aarch64]
-  sha256: 8f960b22594a91dbad7e78cc91acb92a2a87607b2f46085fe6ecd6173747467a  # [win64]
+  sha256: 98d9559da6c1d880b71e7618d266f4e912ea4330f137d78f195781cb7864042f  # [linux64]
+  sha256: 1621f950b91929abf05ab581b16a71285370523540d7be3fdf6fc1259e44f6ac  # [ppc64le]
+  # sha256: 031b75946d2ce22f8c2736f7b4216b9377406afcb35012093a66e2801bfe2990  # [aarch64]
+  sha256: faec7c8c5783fa7e06d5ec41c9372dee3f9a14d155038539a6bf52a6ce31f25e  # [win64]
 
 build:
-  number: 4
-  skip: True  # [win32 or cuda_compiler_version in ("None", "9.2", "10.0", "11.1", "11.2")]
+  number: 0
+  # cuTENSOR v1.3.1 supports CUDA 10.2, 11.0, and 11.1+
+  skip: True  # [win32 or cuda_compiler_version not in ("10.2", "11.0", "11.1")]
   script_env:
     # for some reason /usr/local/cuda is not added to $PATH in ppc64le's docker image
     - CUDA_HOME  # [ppc64le]
@@ -26,16 +27,16 @@ build:
     - mkdir -p $PREFIX/include                                            # [linux]
     - cp -r include/* $PREFIX/include/                                    # [linux]
     - mkdir -p $PREFIX/lib                                                # [linux]
-    - mv lib/{{ cuda_compiler_version }}/libcutensor.so* $PREFIX/lib/     # [linux and cuda_compiler_version in ("10.1", "10.2")]
-    - mv lib/11/libcutensor.so* $PREFIX/lib/                              # [linux and cuda_compiler_version in ("11.0", )]
+    - mv lib/{{ cuda_compiler_version }}/libcutensor.so* $PREFIX/lib/     # [linux and cuda_compiler_version in ("10.2", "11.0")]
+    - mv lib/11/libcutensor.so* $PREFIX/lib/                              # [linux and cuda_compiler_version == "11.1"]
 
     - copy include\\cutensor.h %LIBRARY_INC%\\                             # [win64]
     - mkdir %LIBRARY_INC%\\cutensor                                        # [win64]
     - copy include\\cutensor\\types.h %LIBRARY_INC%\\cutensor              # [win64]
-    - copy lib\\{{ cuda_compiler_version }}\\cutensor.dll %LIBRARY_BIN%\\  # [win64 and cuda_compiler_version in ("10.1", "10.2")]
-    - copy lib\\{{ cuda_compiler_version }}\\cutensor.lib %LIBRARY_LIB%\\  # [win64 and cuda_compiler_version in ("10.1", "10.2")]
-    - copy lib\\11\\cutensor.dll %LIBRARY_BIN%\\                           # [win64 and cuda_compiler_version in ("11.0", )]
-    - copy lib\\11\\cutensor.lib %LIBRARY_LIB%\\                           # [win64 and cuda_compiler_version in ("11.0", )]
+    - copy lib\\{{ cuda_compiler_version }}\\cutensor.dll %LIBRARY_BIN%\\  # [win64 and cuda_compiler_version in ("10.2", "11.0")]
+    - copy lib\\{{ cuda_compiler_version }}\\cutensor.lib %LIBRARY_LIB%\\  # [win64 and cuda_compiler_version in ("10.2", "11.0")]
+    - copy lib\\11\\cutensor.dll %LIBRARY_BIN%\\                           # [win64 and cuda_compiler_version in ("11.1", )]
+    - copy lib\\11\\cutensor.lib %LIBRARY_LIB%\\                           # [win64 and cuda_compiler_version in ("11.1", )]
   ignore_run_exports_from:
     - {{ compiler('c') }}    # [linux]
     - {{ compiler('cuda') }}
@@ -56,8 +57,8 @@ requirements:
     - libgcc-ng >=3.0     # [linux]
     # Only GLIBCXX_3.4 or older symbols present
     - libstdcxx-ng >=3.4  # [linux]
-    - cudatoolkit {{ cuda_compiler_version }}  # [cuda_compiler_version in ("10.1", "10.2")]
-    - cudatoolkit 11.*                         # [cuda_compiler_version not in ("10.1", "10.2")]
+    - cudatoolkit {{ cuda_compiler_version }}  # [cuda_compiler_version in ("10.2", "11.0")]
+    - cudatoolkit 11.*                         # [cuda_compiler_version == "11.1"]
   run_constrained:
     # Only GLIBC_2.17 or older symbols present
     - __glibc >=2.17      # [linux]
@@ -71,7 +72,7 @@ test:
     - sysroot_linux-64 2.17  # [linux]
     # make sure we pick up the version matching the docker,
     # or the linker would complain 
-    - cudatoolkit 11.0       # [cuda_compiler_version == "11.0"]
+    - cudatoolkit {{ cuda_compiler_version }}
   commands:
     - test -f $PREFIX/include/cutensor.h                    # [linux]
     - test -f $PREFIX/include/cutensor/types.h              # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     # Only GLIBCXX_3.4 or older symbols present
     - libstdcxx-ng >=3.4  # [linux]
     - cudatoolkit {{ cuda_compiler_version }}  # [cuda_compiler_version in ("10.2", "11.0")]
-    - cudatoolkit >=11.1                       # [cuda_compiler_version == "11.1"]
+    - cudatoolkit >=11.1,<12                   # [cuda_compiler_version == "11.1"]
   run_constrained:
     # Only GLIBC_2.17 or older symbols present
     - __glibc >=2.17      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     # Only GLIBCXX_3.4 or older symbols present
     - libstdcxx-ng >=3.4  # [linux]
     - cudatoolkit {{ cuda_compiler_version }}  # [cuda_compiler_version in ("10.2", "11.0")]
-    - cudatoolkit 11.*                         # [cuda_compiler_version == "11.1"]
+    - cudatoolkit >=11.1                       # [cuda_compiler_version == "11.1"]
   run_constrained:
     # Only GLIBC_2.17 or older symbols present
     - __glibc >=2.17      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,10 @@ package:
   version: {{ version }}.{{ patch_version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-x86_64-{{ version }}.{{ patch_version }}.tar.gz   # [linux64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
-  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-ppc64le-{{ version }}.{{ patch_version }}.tar.gz  # [ppc64le and cuda_compiler_version in ("10.1", "10.2", "11.0")]
-  # url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-sbsa-{{ version }}.{{ patch_version }}.tar.gz  # [aarch64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
-  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-windows-x86_64-{{ version }}.{{ patch_version }}.zip  # [win64 and cuda_compiler_version in ("10.1", "10.2", "11.0")]
+  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-x86_64-{{ version }}.{{ patch_version }}.tar.gz   # [linux64]
+  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-ppc64le-{{ version }}.{{ patch_version }}.tar.gz  # [ppc64le]
+  # url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-linux-sbsa-{{ version }}.{{ patch_version }}.tar.gz     # [aarch64]
+  url: https://developer.download.nvidia.com/compute/cutensor/{{ version }}/local_installers/libcutensor-windows-x86_64-{{ version }}.{{ patch_version }}.zip    # [win64]
 
   sha256: 98d9559da6c1d880b71e7618d266f4e912ea4330f137d78f195781cb7864042f  # [linux64]
   sha256: 1621f950b91929abf05ab581b16a71285370523540d7be3fdf6fc1259e44f6ac  # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ about:
   home: https://developer.nvidia.com/cutensor
   license: LicenseRef-cuTENSOR-Software-License-Agreement
   license_url: https://docs.nvidia.com/cuda/cutensor/license.html
-  license_file: license.pdf
+  license_file: license.txt
   summary: "Tensor Linear Algebra on NVIDIA GPUs"
   description: |
     The cuTENSOR Library is a first-of-its-kind GPU-accelerated tensor linear


### PR DESCRIPTION
Close #11. Note: CUDA 10.1 is dropped, and we use CUDA 11.1 to build for all CUDA 11.1+.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
