### PR TITLE
Fix ppc64le binary and tests - Part 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: faec7c8c5783fa7e06d5ec41c9372dee3f9a14d155038539a6bf52a6ce31f25e  # [win64]
 
 build:
-  number: 1
+  number: 2
   # cuTENSOR v1.3.1 supports CUDA 10.2, 11.0, and 11.1+
   skip: True  # [win32 or cuda_compiler_version not in ("10.2", "11.0", "11.1")]
   script_env:
@@ -29,6 +29,7 @@ build:
     - mkdir -p $PREFIX/lib                                                # [linux]
     - mv lib/{{ cuda_compiler_version }}/libcutensor.so* $PREFIX/lib/     # [linux and cuda_compiler_version in ("10.2", "11.0")]
     - mv lib/11/libcutensor.so* $PREFIX/lib/                              # [linux and cuda_compiler_version == "11.1"]
+    - patchelf --add-needed libcudart.so $PREFIX/lib/libcutensor.so       # [ppc64le]
 
     - copy include\\cutensor.h %LIBRARY_INC%\\                             # [win64]
     - mkdir %LIBRARY_INC%\\cutensor                                        # [win64]

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -4,11 +4,7 @@ set -ex
 test -f $PREFIX/include/cutensor.h
 test -f $PREFIX/include/cutensor/types.h
 test -f $PREFIX/lib/libcutensor.so
-TEST_LINKER_FLAGS=""
-if [[ $target_platform == linux-ppc64le ]]; then
-    TEST_LINKER_FLAGS+=" -L/usr/local/cuda/lib64 -lcudart"
-fi
-${GCC} test_load_elf.c -std=c99 -Werror -ldl $TEST_LINKER_FLAGS -o test_load_elf
+${GCC} test_load_elf.c -std=c99 -Werror -ldl -o test_load_elf
 ./test_load_elf $PREFIX/lib/libcutensor.so
 
 NVCC_FLAGS=""


### PR DESCRIPTION
This is needed because on linux64 libcutensor.so is linked to libcublasLt.so, which supposedly hides the CUDA Runtime symbols. On ppc64le it is not.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
