### PR TITLE
WIP: Add `cuda-version` to `run_constrained` for pre-CUDA 12 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,6 @@ In order to produce a uniquely identifiable distribution:
    the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
-<!-- add dummy commit to try retriggering CI -->
-
 Feedstock Maintainers
 =====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,10 +5,10 @@ package:
   version: {{ version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cutensor/libcutensor/linux-x86_64/libcutensor-linux-x86_64-{{ version }}-archive.tar.xz  # [linux64]
-  url: https://developer.download.nvidia.com/compute/cutensor/libcutensor/linux-ppc64le/libcutensor-linux-ppc64le-{{ version }}-archive.tar.xz  # [ppc64le]
-  url: https://developer.download.nvidia.com/compute/cutensor/libcutensor/linux-sbsa/libcutensor-linux-sbsa-{{ version }}-archive.tar.xz  # [aarch64]
-  url: https://developer.download.nvidia.com/compute/cutensor/libcutensor/windows-x86_64/libcutensor-windows-x86_64-{{ version }}-archive.zip  # [win64]
+  url: https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-x86_64/libcutensor-linux-x86_64-{{ version }}-archive.tar.xz  # [linux64]
+  url: https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-ppc64le/libcutensor-linux-ppc64le-{{ version }}-archive.tar.xz  # [ppc64le]
+  url: https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/linux-sbsa/libcutensor-linux-sbsa-{{ version }}-archive.tar.xz  # [aarch64]
+  url: https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/windows-x86_64/libcutensor-windows-x86_64-{{ version }}-archive.zip  # [win64]
 
   sha256: dd3557891371a19e73e7c955efe5383b0bee954aba6a30e4892b0e7acb9deb26  # [linux64]
   sha256: af4ad5e29dcb636f1bf941ed1fd7fc8053eeec4813fbc0b41581e114438e84c8  # [ppc64le]
@@ -16,7 +16,7 @@ source:
   sha256: cdbb53bcc1c7b20ee0aa2dee781644a324d2d5e8065944039024fe22d6b822ab  # [win64]
 
 build:
-  number: 0
+  number: 1
   # cuTENSOR v1.3.1 supports CUDA 10.2, 11.0, and 11.1+
   skip: true  # [win32 or cuda_compiler_version not in ("10.2", "11.0", "11.1")]
   script_env:
@@ -62,6 +62,9 @@ requirements:
   run_constrained:
     # Only GLIBC_2.17 or older symbols present
     - __glibc >=2.17      # [linux]
+    - cuda-version 10.2        # [cuda_compiler_version == "10.2"]
+    - cuda-version 11.0        # [cuda_compiler_version == "11.0"]
+    - cuda-version >=11.1,<12  # [cuda_compiler_version == "11.1"]
 
 test:
   requires:


### PR DESCRIPTION
Part of #41.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
